### PR TITLE
Transmits the error message when no route

### DIFF
--- a/api/v01/api.rb
+++ b/api/v01/api.rb
@@ -37,7 +37,7 @@ module Api
         end
 
         response = {message: e.message}
-        if e.is_a?(RangeError) || e.is_a?(Grape::Exceptions::ValidationErrors)
+        if e.is_a?(RangeError) || e.is_a?(Grape::Exceptions::ValidationErrors) || e.is_a?(RouterWrapper::NoRouteFound)
           rack_response(format_message(response, e.backtrace), 400)
         elsif e.is_a?(Grape::Exceptions::MethodNotAllowed)
           rack_response(format_message(response, nil), 405)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,6 +18,7 @@
 require 'active_support'
 require 'dotenv'
 require 'tmpdir'
+require 'byebug'
 
 require './wrappers/crow'
 require './wrappers/osrm5'

--- a/router_wrapper.rb
+++ b/router_wrapper.rb
@@ -162,6 +162,9 @@ module RouterWrapper
   class InvalidArgumentError < RouterWrapperError
   end
 
+  class NoRouteFound < RouterWrapperError
+  end
+
   private
 
   def self.speed_multiplier_area(params)

--- a/wrappers/here.rb
+++ b/wrappers/here.rb
@@ -17,7 +17,6 @@
 #
 require './wrappers/wrapper'
 
-
 module Wrappers
   class Here < Wrapper
 
@@ -331,7 +330,9 @@ module Wrappers
               elsif additional_data.include?({ 'key' => 'error_code', 'value' => 'NGEO_ERROR_ROUTE_NO_START_POINT' })
                 raise UnreachablePointError
               elsif error['subtype'] == 'InvalidInputData'
-                raise RouterWrapper::InvalidArgumentError.new(error), "Here, #{error['subtype']} : #{error['details']} (#{additional_data.first['key']} : #{additional_data.first['value']})"
+                raise RouterWrapper::InvalidArgumentError.new(error), "Here, #{error['subtype']}: #{error['details']} (#{additional_data.first['key']} : #{additional_data.first['value']})"
+              elsif error['subtype'] == 'NoRouteFound'
+                raise RouterWrapper::NoRouteFound.new(error), "Here, #{error['subtype']}: #{params.keys.grep(/waypoint/).map{|key| params[key]}}"
               else
                 raise
               end


### PR DESCRIPTION
When the HERE router returns a message about an error on a route, we use to return a 400 Bad request. It is hard to determine what was wrong. 

This PR handle this case and return a message like : `Here, NoRouteFound: ["geo!32.80446,35.73093", "geo!32.98762,35.67872"]` that a tiers application can use.