### PR TITLE
Fix crow distance calculation

### DIFF
--- a/lib/earth.rb
+++ b/lib/earth.rb
@@ -22,7 +22,7 @@ module RouterWrapper
     DEG_PER_RAD = 180 / Math::PI
     RM = 6371000 # Earth radius in meters
 
-    def self.distance_between(lat1, lon1, lat2, lon2)
+    def self.distance_between(lon1, lat1, lon2, lat2)
       lat1_rad = lat1 * RAD_PER_DEG
       lat2_rad = lat2 * RAD_PER_DEG
       lon1_rad = lon1 * RAD_PER_DEG

--- a/test/wrappers/crow_test.rb
+++ b/test/wrappers/crow_test.rb
@@ -25,12 +25,14 @@ class Wrappers::CrowTest < Minitest::Test
     result = crow.route([[49.610710, 18.237305], [47.010226, 2.900391]], :time, nil, nil, 'en', true, {motorway: true, toll: true})
     assert !result[:features].empty?
     assert !result[:features][0][:geometry].empty?
+    assert_equal 1168235, result[:features][0][:properties][:router][:total_distance].to_i
   end
 
   def test_matrix
     crow = RouterWrapper::CROW
     result = crow.matrix([[49.610710, 18.237305]], [[47.010226, 2.900391]], :time, nil, nil, 'en', {motorway: true, toll: true})
     assert !result[:matrix_time].empty?
+    assert_equal 1168235, result[:matrix_time].flatten.first.to_i
   end
 
   def test_isoline


### PR DESCRIPTION
Since we have seen the coordinates were reversed, this PR fixes it. 

One strange thing I haven't changed is that we pass the mode (distance/time) to the `route` and `matrix` methods, but they are not used. This is particularly strange for the matrix method as we always return the time.