### PR TITLE
HERE: Corrects the distance coef for matrices

### DIFF
--- a/test/wrappers/here_test.rb
+++ b/test/wrappers/here_test.rb
@@ -159,4 +159,17 @@ class Wrappers::HereTest < Minitest::Test
 
     assert here.matrix(vector, vector, :time, nil, nil, 'en', hazardous_goods: nil)
   end
+
+  def test_distance_should_return_coef
+    # 100km: 7, 1200km: 2, 1400km: 1
+    here = RouterWrapper::HERE_TRUCK
+    [
+      { m: 100_000, coef: 7 },
+      { m: 1_200_000, coef: 2 },
+      { m: 1_200_000.98123721931, coef: 2 },
+      { m: 1_400_000, coef: 1 }
+    ].each do |obj|
+      assert_equal(here.send(:coef_distance, obj[:m]), obj[:coef])
+    end
+  end
 end

--- a/wrappers/here.rb
+++ b/wrappers/here.rb
@@ -184,9 +184,8 @@ module Wrappers
         lats = (srcs + dsts).minmax_by{ |p| p[0] }
         lons = (srcs + dsts).minmax_by{ |p| p[1] }
         dist = RouterWrapper::Earth.distance_between(lats[1][0], lons[1][1], lats[0][0], lons[0][1])
-        coef_distance = 7 - [dist / 200, 6.0].min # 100km: 7, 1200km: 2, 1400km: 1
 
-        srcs_split = [100 / [(dsts.size / coef_distance).ceil, 100].min, (1000 / srcs.size.to_f).ceil].min
+        srcs_split = [100 / [(dsts.size / coef_distance(dist)).ceil, 100].min, (1000 / srcs.size.to_f).ceil].min
         dsts_split = dsts_max = [100, dsts.size].min
         srcs_split = [srcs_split, 15].min if srcs_split * dsts_split > 99
 
@@ -455,6 +454,13 @@ module Wrappers
 
     def here_strict_restriction(param_value)
       param_value ? 'strict' : 'soft'
+    end
+
+    ##
+    # dist: value in meters
+    # 100km: 7, 1200km: 2, 1400km: 1
+    def coef_distance(dist)
+      7 - [(dist.ceil / 1000) / 201, 6.0].min
     end
   end
 end


### PR DESCRIPTION
The distance was given in meters when the code below thought it was kilometers. This PR corrects that and allows the matrices to be properly sized.