### PR TITLE
Fix here matrix size depending of distances

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,3 +35,30 @@ require 'grape-entity'
 
 require 'minitest/autorun'
 require 'rack/test'
+
+##
+# max_radius in km
+def random_point_in_disk(max_radius)
+  radius = max_radius * 1000 # to meter
+
+  # 0 to 2 Pi excluding 2 Pi because that's just 0.
+  radians = Random.rand(2 * Math::PI)
+
+  # Math.cos/sin work in radians, not degrees.
+  x = radius * Math.cos(radians)
+  y = radius * Math.sin(radians)
+
+  [x, y]
+end
+
+##
+# max_radius in km
+def random_location(centroid, max_radius)
+  earth_radius = 6371 # km
+  one_degree = earth_radius * 2 * Math::PI / 360 * 1000 # 1 degree latitude in meters
+
+  dx, dy = random_point_in_disk(max_radius)
+  random_lat = centroid[:lat] + dy / one_degree
+  random_lng = centroid[:lng] + dx / (one_degree * Math.cos(centroid[:lat] * Math::PI / 180))
+  [random_lat.round(5), random_lng.round(5)] # meter precision
+end

--- a/test/wrappers/here_test.rb
+++ b/test/wrappers/here_test.rb
@@ -159,4 +159,19 @@ class Wrappers::HereTest < Minitest::Test
 
     assert here.matrix(vector, vector, :time, nil, nil, 'en', hazardous_goods: nil)
   end
+
+  def test_distance_should_define_row_number
+    [
+      { distance: 100, max_srcs: 15 },
+      { distance: 1_000, max_srcs: 15 },
+      { distance: 1_500, max_srcs: 10 },
+      { distance: 1_700, max_srcs: 8 },
+      { distance: 1_800, max_srcs: 7 },
+      { distance: 1_900, max_srcs: 6 },
+      { distance: 2_000, max_srcs: 5 },
+      { distance: 3_000, max_srcs: 1 }
+    ].each do |obj|
+      assert_equal(RouterWrapper::HERE_TRUCK.send(:max_srcs, obj[:distance]), obj[:max_srcs])
+    end
+  end
 end


### PR DESCRIPTION
Currently we cut the matrices into too small sizes resulting in too much time. 

For example a 200x200 matrix with diagonal around 100km takes 3 m 22 s. When the distances are close to 1000km, it ends up in timeout.

With this fix, a 200x200 ~100km takes 36 s  and for 1000km, 13 minutes.